### PR TITLE
Allow configuration to point to ENV and use basic auth for solr

### DIFF
--- a/Config/run-20.conf
+++ b/Config/run-20.conf
@@ -94,11 +94,13 @@ solr_hl_fragsize = 300
 num_shards_list    = 1
 
 #
-# Server key to virtual server URI 
+# Talking to solr
 #
-mbooks_solr_engines     = http://solr-sdr-dev:8112/ptsearch
-engine_for_shard_1      = http://solr-sdr-dev:8112/ptsearch
-prod_engine_for_shard_1 = http://solr-sdr-ptsearch:8080/ptsearch
+# We now get the solr url from an environment variable, and use basic auth to talk to solr
+
+solr_basic_auth_token = ENV[PTSEARCH_SOLR_BASIC_AUTH]
+engine_for_shard_1 = ENV[PTSEARCH_SOLR]
+prod_engine_for_shard_1 = ENV[PTSEARCH_SOLR]
 
 #
 # shard to index directory map

--- a/Config/run-22.conf
+++ b/Config/run-22.conf
@@ -97,11 +97,14 @@ solr_hl_fragsize = 300
 num_shards_list    = 1
 
 #
-# Server key to virtual server URI 
+# Talking to solr
 #
-mbooks_solr_engines     = http://solr-sdr-ptsearch:8080/ptsearch
-engine_for_shard_1      = http://solr-sdr-ptsearch:8080/ptsearch
-prod_engine_for_shard_1 = http://solr-sdr-ptsearch:8080/ptsearch
+# We now get the solr url from an environment variable, and use basic auth to talk to solr
+
+solr_basic_auth_token = ENV[PTSEARCH_SOLR_BASIC_AUTH]
+engine_for_shard_1 = ENV[PTSEARCH_SOLR]
+prod_engine_for_shard_1 = ENV[PTSEARCH_SOLR]
+
 
 #
 # shard to index directory map

--- a/Search/Searcher.pm
+++ b/Search/Searcher.pm
@@ -108,7 +108,7 @@ sub __Solr_result {
     my ($C, $query_string, $rs) = @_;
 
     my $url = $self->__get_Solr_select_url($C, $query_string);
-    my $req = $self->__get_request_object($url);
+    my $req = $self->__get_request_object($url, $C);
     my $ua = $self->__create_user_agent();
 
     if (DEBUG('query')) {
@@ -209,6 +209,7 @@ Description
 sub __get_request_object {
     my $self = shift;
     my $uri = shift;
+    my $C = shift;
 
     my ($url, $query_string) = (split(/\?/, $uri));  
 
@@ -223,10 +224,23 @@ sub __get_request_object {
     my $req = HTTP::Request->new('POST', $url, undef, $query_string);
 
     $req->header( 'Content-Type' => 'application/x-www-form-urlencoded; charset=utf8'  );
-    
+    $req = add_basic_auth($req, $C) if ($C);
     return $req;
 }
 
+sub add_basic_auth {
+    my $req = shift;
+    my $C = shift;
+
+    my $key = 'solr_basic_auth_token';
+
+    my $config = my $config = $C->get_object('MdpConfig');
+    if ($config->has($key)) {
+        my $token = $config->get($key);
+        $req->header('Authorization' => "Basic $token");
+    }
+    return $req;
+}
 
 # ---------------------------------------------------------------------
 

--- a/Search/Searcher/ExportSearcher.pm
+++ b/Search/Searcher/ExportSearcher.pm
@@ -73,7 +73,7 @@ sub __Solr_export_result {
     my ($C, $query_string, $rs) = @_;
 
     my $url = $self->__get_Solr_export_url($C, $query_string);
-    my $req = $self->__get_request_object($url);
+    my $req = $self->__get_request_object($url, $C);
     my $ua = $self->__create_user_agent();
 
     if (DEBUG('query')) {


### PR DESCRIPTION
Several changes:
  * The two ptsearch configs (run-20 and run-22) remove the
    list of solr URLs in favor of using new MdpConfig
    ability to reference ENV[PTSEARCH_SOLR]
  * run-20 and run-22 also define the basic auth token as coming
    from ENV[PTSEARCH_SOLR_BASIC_AUTH]
  * Search/Searcher and Search/Indexer will now add a basic
    auth token in `__get_request_object` if the configuration variable
    `solr_basic_auth_token` is set. The string 'Basic ' is prepended in
    the code, not in the config (so the token in the config does NOT start
    with 'Basic')
  * To facilitate the auth, $C is passed to `__get_request_object`