### PR TITLE
For solr 8: use wt=xml&indent=off by default

### DIFF
--- a/Search/Searcher.pm
+++ b/Search/Searcher.pm
@@ -107,6 +107,8 @@ sub __Solr_result {
     my $self = shift;
     my ($C, $query_string, $rs) = @_;
 
+    $query_string .= "&wt=xml&indent=off" unless $query_string =~ /\bwt=\b/;
+
     my $url = $self->__get_Solr_select_url($C, $query_string);
     my $req = $self->__get_request_object($url, $C);
     my $ua = $self->__create_user_agent();


### PR DESCRIPTION
slip-lib makes assumptions that the return format is the same as in solr 6, which is xml without any whitespace added. This breaks in solr 8 where the default is wt=json and indent=on.

I guess the question is whether the proposed addition is likely to break anything in production and/or how we might test that...